### PR TITLE
fix: Cookie is not settled with a remote API endpoint

### DIFF
--- a/src/app/interceptors/api-request.interceptor.ts
+++ b/src/app/interceptors/api-request.interceptor.ts
@@ -35,7 +35,8 @@ export class ApiRequestInterceptor implements HttpInterceptor {
 
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     request = request.clone({
-      setHeaders: { 'X-Requested-With': 'XMLHttpRequest', withCredentials: 'true' }
+      setHeaders: { 'X-Requested-With': 'XMLHttpRequest' },
+      withCredentials: true
     });
     this.loaderService.show();
 


### PR DESCRIPTION
fix gravitee-io/issues#2977