### PR TITLE
fix: remove "top Apis" in homepage if no top Apis

### DIFF
--- a/src/app/pages/homepage/homepage.component.html
+++ b/src/app/pages/homepage/homepage.component.html
@@ -19,7 +19,7 @@
   <section>
     <app-gv-page *ngIf="homepage" [page]="homepage"></app-gv-page>
   </section>
-  <section *ngIf="topApis">
+  <section *ngIf="topApis.length > 0">
     <h2>{{'homepage.apis' | translate}}</h2>
     <gv-card-list [items]="topApis"></gv-card-list>
   </section>

--- a/src/app/pages/homepage/homepage.component.ts
+++ b/src/app/pages/homepage/homepage.component.ts
@@ -28,7 +28,7 @@ import '@gravitee/ui-components/wc/gv-card-list';
 export class HomepageComponent implements OnInit {
 
   public homepage: Page;
-  public topApis: { item: Api; metric: Promise<ApiMetrics> }[];
+  public topApis: { item: Api; metric: Promise<ApiMetrics> }[] = [];
 
   constructor(
     private portalService: PortalService,


### PR DESCRIPTION
fix gravitee-io/issues#3643