### PR TITLE
fix(management): do not add empty tokens in HTTP headers

### DIFF
--- a/src/app/interceptors/api-request.interceptor.ts
+++ b/src/app/interceptors/api-request.interceptor.ts
@@ -45,12 +45,21 @@ export class ApiRequestInterceptor implements HttpInterceptor {
 
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
 
+    let headers = {
+      'X-Requested-With': 'XMLHttpRequest'
+    }
+
+    if (this.xsrfToken) {
+      headers['X-Xsrf-Token'] = this.xsrfToken;
+    }
+
+    let currentReCaptchaToken = this.reCaptchaService.getCurrentToken();
+    if (currentReCaptchaToken) {
+      headers['X-Recaptcha-Token'] = currentReCaptchaToken;
+    }
+
     request = request.clone({
-      setHeaders: {
-        'X-Requested-With': 'XMLHttpRequest',
-        'X-Xsrf-Token': [ this.xsrfToken ],
-        'X-Recaptcha-Token': [ this.reCaptchaService.getCurrentToken() ]
-      },
+      setHeaders: headers,
       withCredentials: true
     });
 


### PR DESCRIPTION
* add X-Xsrf-Token only if not empty
* add X-ReCaptcha-Token only if not empty

Fixes gravitee-io/issues#4628