### PR TITLE
fix(portal): don't allow a user to click on an unpublished API detail

### DIFF
--- a/src/app/pages/application/application-subscriptions/application-subscriptions.component.ts
+++ b/src/app/pages/application/application-subscriptions/application-subscriptions.component.ts
@@ -125,6 +125,7 @@ export class ApplicationSubscriptionsComponent implements OnInit {
           {
             type: 'gv-button',
             width: '25px',
+            condition: (item) => this.metadata[item.api] &&  this.metadata[item.api].state === 'published',
             attributes: {
               link: true,
               href: (item) => `/catalog/api/${item.api}`,


### PR DESCRIPTION
Fixes gravitee-io/issues#4836