### PR TITLE
Make base href relative to serving path

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -20,7 +20,7 @@
 <head>
   <meta charset="utf-8">
   <title>Gravitee.io Portail</title>
-  <base href="/">
+  <base href="./">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="shortcut icon" href="favicon.ico">
   <link rel="icon" type="image/png" href="favicon.png" sizes="96x96">


### PR DESCRIPTION
When serving the portal behind a reverse proxy, client generate URL based on 'base' tag. To re-use the proper reverse-proxy configuration, this base tag should be a relative path.