### PR TITLE
fix(portal): hide application creation button

### DIFF
--- a/src/app/pages/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/dashboard.component.ts
@@ -158,7 +158,11 @@ export class DashboardComponent implements OnInit {
   }
 
   applicationCreationEnabled() {
-    return this.applications && this.config.hasFeature(FeatureEnum.applicationCreation);
+    return (
+      this.applications &&
+      this.config.hasFeature(FeatureEnum.applicationCreation) &&
+      this.currentUser?.permissions?.APPLICATION.find((permission) => 'C' === permission)
+    );
   }
 
   onSubscriptionClick({ detail }) {


### PR DESCRIPTION
On the dashboard page, check the user's permissions

Fixes gravitee-io/issues#5403