### PR TITLE
fix: fix apikey revokal from application subscriptions page

### DIFF
--- a/src/app/pages/application/application-subscriptions/application-subscriptions.component.html
+++ b/src/app/pages/application/application-subscriptions/application-subscriptions.component.html
@@ -128,7 +128,7 @@
           <gv-confirm
             [message]="'application.subscriptions.apiKey.revoke.message' | translate"
             danger
-            (:gv-confirm:ok)="revokeApiKey(selectedSubscriptions[0], apiKey.key)"
+            (:gv-confirm:ok)="revokeApiKey(selectedSubscription.id, apiKey.key)"
             [cancelLabel]="'common.cancel' | translate"
             [okLabel]="'common.ok' | translate"
           >


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6226

Use selectedSubscription.id to revoke apiKey, instead of selectedSubscriptions[0], which leads to call revoke with a wrong subscription id