### PR TITLE
Update swagger-ui-dist version

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "redoc": "^2.0.0-rc.53",
     "resize-observer-polyfill": "^1.5.1",
     "rxjs": "6.5.5",
-    "swagger-ui-dist": "^3.25.0",
+    "swagger-ui-dist": "^3.52.3",
     "tslib": "^1.11.1",
     "zone.js": "~0.10.2"
   },


### PR DESCRIPTION
Update swagger-ui-dist version since it causes different behaviour in APIM Console and API Portal. Changed to the version that used in console to users have expected results in portal. Old version had bugs, such as not showing example values for parameters.