### PR TITLE
fix: fix api key display in 'my subscriptions' tab

### DIFF
--- a/src/app/pages/subscriptions/subscriptions.component.ts
+++ b/src/app/pages/subscriptions/subscriptions.component.ts
@@ -177,7 +177,7 @@ export class SubscriptionsComponent implements OnInit {
     const entrypoints = this.subscriptionsMetadata[sub.subscription.api].entrypoints;
     const entrypoint = entrypoints && entrypoints[0] && entrypoints[0].target;
     if (entrypoint && keys[0]) {
-      this.curlExample = `curl ${entrypoint} -H "${this.apikeyHeader}:${keys[0].id}"`;
+      this.curlExample = `curl ${entrypoint} -H "${this.apikeyHeader}:${keys[0].key}"`;
     }
   }
 


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6413

fix: fix api key display in 'my subscriptions' tab
It was displaying key.id instead of key.key

**How to test**
Go to the main tab "Applications" > tab "Mes Souscriptions"
Select an API key subscription.
Check the above curl command.
